### PR TITLE
Automatically bump BinderHub chart version

### DIFF
--- a/.github/workflows/binderhub-bump.yml
+++ b/.github/workflows/binderhub-bump.yml
@@ -1,0 +1,26 @@
+name: binderhub-bump
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '16 3 * * *'
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: python -mpip install -r binderhub-bump/requirements.txt
+      - run: |
+          ./binderhub-bump/bump.py
+          git diff
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          branch: binderhub-bump
+          title: "Bump BinderHub Helm Chart"
+          body: |
+            Bump BinderHub Helm Chart
+          commit-message: |
+            Bump BinderHub Helm Chart

--- a/binderhub-bump/bump.py
+++ b/binderhub-bump/bump.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# Must be run from the directory containing helmsman.yaml
+
+import requests
+from ruamel.yaml import YAML
+# semver>=3.0.0-dev.2
+import semver
+
+
+# Using ruamel instead of pyyaml allows round-tripping (preserves formatting)
+# of the input YAML file
+yaml = YAML(typ='rt')
+yaml.preserve_quotes = True
+yaml.indent(mapping=2, offset=2, sequence=4)
+
+
+with open('helmsman.yaml') as fin:
+    helmsman = yaml.load(fin)
+current = helmsman['appsTemplates']['binderhub']['version']
+print(f'Current version: {current}')
+
+
+helmindex = 'https://jupyterhub.github.io/helm-chart/index.yaml'
+y = yaml.load(requests.get(helmindex).content)
+component = y['entries']['binderhub']
+# component = y['entries']['jupyterhub']
+
+valid_semver = []
+invalid_semver = []
+for e in component:
+    try:
+        e['semver'] = semver.Version.parse(e['version'])
+        valid_semver.append(e)
+    except ValueError:
+        invalid_semver.append(e)
+
+ordered_by_version = sorted(valid_semver, key=lambda e: e['semver'])
+releases = [e for e in ordered_by_version if not e['semver'].prerelease]
+
+print(f'Found {len(component)} versions including {len(releases)} releases')
+print(f'Ignored {len(invalid_semver)} invalid versions')
+if releases:
+    print(f"Latest available release: {releases[-1]['version']}")
+latest = ordered_by_version[-1]['version']
+print(f'Latest available version including prereleases: {latest}')
+
+if current != latest:
+    print(f'Updating version: {current} ➜ {latest}')
+    helmsman['appsTemplates']['binderhub']['version'] = latest
+    with open('helmsman.yaml', 'w') as fout:
+        yaml.dump(helmsman, fout)
+else:
+    print(f'Already up to date: {current}')

--- a/binderhub-bump/requirements.txt
+++ b/binderhub-bump/requirements.txt
@@ -1,0 +1,3 @@
+requests
+semver>=3.0.0-dev.2
+ruamel.yaml


### PR DESCRIPTION
Ages ago I said I'd look at automatically bumping the BinderHub chart version. This python script should make the update. I've added a GitHub workflow that runs the script and automatically opens a PR.

If you want to run it on GitLab instead you could use the [GitLab merge request API](https://docs.gitlab.com/ee/api/merge_requests.html#create-mr) instead